### PR TITLE
グレードアップ購入対応

### DIFF
--- a/src/contents/main/ConfirmOrder.jsx
+++ b/src/contents/main/ConfirmOrder.jsx
@@ -125,7 +125,7 @@ const ConfirmOrder = (props) => {
                 <p><label htmlFor="confirmForm_code">認証コード</label></p>
             </Col>
             <Col xs="6" md="6" className="mb-2">
-                <input name="confirmationCode" onChange={handleChange} id="confirmForm_code" className="form-control" />
+                <input name="confirmationCode" onChange={handleChange} onKeyDown={(e) => { if (e.key === "Enter" && successButton) handleSubmit(); }} id="confirmForm_code" className="form-control" />
             </Col>
         </Row>
         <Row className="p2 mt-2">
@@ -150,6 +150,9 @@ const sendOrder = (formData, setMessage, setFormData, setOrderStep, setSerialnum
     let requestData = {...formData};
     if (formData.isCouponApplied) {
         requestData.couponCode = formData.couponCode;
+    }
+    if (formData.isSnValidated) {
+        requestData.serial_number = formData.serialNumber;
     }
 
     axios.post(settings.apiUrl + "order", requestData).then((r) => {

--- a/src/contents/main/InputForm.jsx
+++ b/src/contents/main/InputForm.jsx
@@ -358,9 +358,7 @@ const InputForm = (props) => {
                         <p><label htmlFor="orderForm-paymentType">支払い方法</label></p>
                     </Col>
                     <Col xs="6" md="9" className="pb-2 mb-2">
-                        <Col md="5">
-                            <select id="orderForm-paymentType" name="paymentType" value={formData.paymentType} onChange={handleChange} className="form-control">{paymentTypeCombo}</select>
-                        </Col>
+                        <select id="orderForm-paymentType" name="paymentType" value={formData.paymentType} onChange={handleChange} className="form-control">{paymentTypeCombo}</select>
                     </Col>
                 </>
             )}

--- a/src/contents/main/InputForm.jsx
+++ b/src/contents/main/InputForm.jsx
@@ -4,6 +4,7 @@ import { Row, Col, Button } from "react-bootstrap";
 
 import settings from "../../settings";
 import constants from "../../constants";
+import ModalDialog from "./ModalDialog";
 
 
 const InputForm = (props) => {
@@ -14,13 +15,18 @@ const InputForm = (props) => {
         paymentType: props.orderFormData.paymentType,
         couponCode: props.orderFormData.couponCode,
         discountAmount: props.orderFormData.discountAmount,
-        isCouponApplied: props.orderFormData.isCouponApplied
+        isCouponApplied: props.orderFormData.isCouponApplied,
+        serialNumber: props.orderFormData.serialNumber,
+        isSnValidated: props.orderFormData.isSnValidated
     });
     const [couponInputValue, setCouponInputValue] = useState(
         props.orderFormData.isCouponApplied ? props.orderFormData.couponCode : ""
     );
     const [couponMessage, setCouponMessage] = useState("");
     const [isApplyingCoupon, setIsApplyingCoupon] = useState(false);
+    const [isApplyingSn, setIsApplyingSn] = useState(false);
+    const [snDialogMessage, setSnDialogMessage] = useState("");
+    const [showSnDialog, setShowSnDialog] = useState(false);
     const handleChange = (e) => {
         let k = e.target.name;
         let newValue = e.target.value;
@@ -69,6 +75,32 @@ const InputForm = (props) => {
             setCouponMessage("エラーが発生しました。時間をおいて再度お試しください。");
         } finally {
             setIsApplyingCoupon(false);
+        }
+    };
+
+    const handleSnValidate = async () => {
+        setIsApplyingSn(true);
+        try {
+            const response = await axios.post(settings.apiUrl + "grade_up_validate", {
+                product_id: props.productInformation.productId,
+                serial_number: formData.serialNumber
+            });
+            if (response.data.code === 200 && response.data.result === "") {
+                setFormData(s => ({...s, isSnValidated: true}));
+                setSnDialogMessage("入力内容が確認されました。");
+                setShowSnDialog(true);
+            } else if (response.data.code === 200) {
+                setSnDialogMessage(response.data.result);
+                setShowSnDialog(true);
+            } else {
+                setSnDialogMessage(response.data.reason || "エラーが発生しました。時間をおいて再度お試しください。");
+                setShowSnDialog(true);
+            }
+        } catch (e) {
+            setSnDialogMessage("エラーが発生しました。時間をおいて再度お試しください。");
+            setShowSnDialog(true);
+        } finally {
+            setIsApplyingSn(false);
         }
     };
 
@@ -127,7 +159,7 @@ const InputForm = (props) => {
         });
     }
 
-    let message = validateForm(formData);
+    let message = validateForm(formData, props.productInformation.require_sn_prefix);
     let nextButton = false;
     if (message === "") {
         message = "次の画面で、あなたのメールアドレスと注文内容を確認します。";
@@ -155,6 +187,11 @@ const InputForm = (props) => {
     }
     
     return (<>
+        <ModalDialog
+            show={showSnDialog}
+            message={snDialogMessage}
+            onClose={() => setShowSnDialog(false)}
+        />
         <Row className="bg-primary text-white mb-4">
             <h2>注文情報入力</h2>
         </Row>
@@ -202,12 +239,46 @@ const InputForm = (props) => {
             <Col xs="12" md="9" className="pb-2 mb-2">
                 <input name="email" value={formData.email} onChange={handleChange} className="form-control" id="orderForm-email" type="text"/>
             </Col>
+            {props.productInformation.require_sn_prefix && (<>
+            <Col xs="12" md="3">
+                <p><label htmlFor="orderForm-serialNumber">シリアルキー</label></p>
+            </Col>
+            <Col xs="12" md="9" className="pb-2 mb-2">
+                <Row>
+                    <Col xs="8" md="6">
+                        <input
+                            name="serialNumber"
+                            value={formData.serialNumber}
+                            onChange={handleChange}
+                            className="form-control"
+                            id="orderForm-serialNumber"
+                            type="text"
+                            maxLength={19}
+                            disabled={formData.isSnValidated}
+                            placeholder={props.productInformation.require_sn_prefix + "ではじまるシリアルキーを入力"}
+                        />
+                    </Col>
+                    <Col xs="4" md="3">
+                        <Button
+                            onClick={handleSnValidate}
+                            variant="primary"
+                            disabled={formData.serialNumber === "" || formData.isSnValidated || isApplyingSn}
+                        >
+                            確認
+                        </Button>
+                    </Col>
+                </Row>
+                {formData.isSnValidated && (
+                    <p className="text-success mt-1">入力内容が確認されました。</p>
+                )}
+            </Col>
+            </>)}
             <Col xs="6" md="3">
                 <p><label htmlFor="orderForm-quantity">購入個数</label></p>
             </Col>
             <Col xs="6" md="9" className="pb-2 mb-2">
                 <Col md="3">
-                    <select id="orderForm-quantity" name="quantity" value={formData.quantity} onChange={handleChange} className="form-control">{quantityCombo}</select>
+                    <select id="orderForm-quantity" name="quantity" value={formData.quantity} onChange={handleChange} className="form-control" disabled={!!props.productInformation.require_sn_prefix}>{quantityCombo}</select>
                 </Col>
             </Col>
             <Col xs="12" md="3">
@@ -305,7 +376,7 @@ const InputForm = (props) => {
     </>);
 }
 
-const validateForm = (data) => {
+const validateForm = (data, requireSnPrefix) => {
     let errMessages = [];
     if (data.name.length < 2) {
         errMessages.push("・お名前を、２文字以上で入力してください。");
@@ -316,7 +387,10 @@ const validateForm = (data) => {
     if ((isNaN(data.quantity)) || (parseInt(data.quantity) <= 0) || (parseInt(data.quantity) > 10)) {
         errMessages.push("・購入個数は、１～10までで指定してください。");
     }
-    
+    if (requireSnPrefix && !data.isSnValidated) {
+        errMessages.push("・シリアルキーを入力し、確認ボタンを押してください。");
+    }
+
     if (errMessages.length === 0) {
         return "";
     } else if(errMessages.length === 3) {

--- a/src/contents/main/OrderFinished.jsx
+++ b/src/contents/main/OrderFinished.jsx
@@ -10,12 +10,21 @@ const OrderFinished = (props) => {
     let message = "";
     let topMessage = "";
     let labelMessage = "";
+    const isGradeUp = !!props.productInformation.require_sn_prefix;
     if (props.orderFormData.paymentType === "credit") {
-        topMessage = "ご注文ありがとうございました。シリアル番号を発行いたしましたので、ご確認の上、大切に保管してください。シリアル番号はメールでもお送りしていますが、この画面を閉じる前にメールの到着を確認してください。";
-        labelMessage = "シリアル番号一覧";
-        message = "* " + props.serialnumbers.join("\n* ");
+        if (isGradeUp) {
+            topMessage = "このたびは追加機能のご購入ありがとうございました。ご注文内容はメールにてお送りしています。この画面を閉じる前にメールの到着を確認してください。";
+        } else {
+            topMessage = "ご注文ありがとうございました。シリアル番号を発行いたしましたので、ご確認の上、大切に保管してください。シリアル番号はメールでもお送りしていますが、この画面を閉じる前にメールの到着を確認してください。";
+            labelMessage = "シリアル番号一覧";
+            message = "* " + props.serialnumbers.join("\n* ");
+        }
     } else if (props.orderFormData.paymentType === "transfer") {
-        topMessage = "ご注文ありがとうございました。7日以内に、以下の内容にてお振込みください。振込先などについてはメールでもお送りしています。お振込みの前に、メールが受信できていることをご確認ください。お支払いが確認できましたら、5営業日以内にシリアル番号をメールにてお送りさせていただきます。";
+        if (isGradeUp) {
+            topMessage = "このたびは追加機能のご注文ありがとうございました。7日以内に、以下の内容にてお振込みください。振込先などについてはメールでもお送りしています。お振込みの前に、メールが受信できていることをご確認ください。お支払いが確認できましたら、5営業日以内にメールにてご連絡さしあげます。";
+        } else {
+            topMessage = "ご注文ありがとうございました。7日以内に、以下の内容にてお振込みください。振込先などについてはメールでもお送りしています。お振込みの前に、メールが受信できていることをご確認ください。お支払いが確認できましたら、5営業日以内にシリアル番号をメールにてお送りさせていただきます。";
+        }
         labelMessage = "お支払い情報";
         message = "振込先:"
             + "\n" + constants.BANK_NAME + constants.BANK_BRANCH
@@ -24,9 +33,13 @@ const OrderFinished = (props) => {
             + "\n* 振込人名には、注文番号と、先ほどご入力されたお名前を指定してください。（例：　13 ヤマダタロウ）"
             + "\n* 上記金額を、振込手数料お客様負担にてお支払いください。";
     } else if (props.orderFormData.paymentType === "free") {
-        topMessage = "ご注文ありがとうございました。無料アップグレード対象のため、決済は発生しませんでした。シリアル番号を発行いたしましたので、ご確認の上、大切に保管してください。シリアル番号はメールでもお送りしていますが、この画面を閉じる前にメールの到着を確認してください。";
-        labelMessage = "シリアル番号一覧";
-        message = "* " + props.serialnumbers.join("\n* ");
+        if (isGradeUp) {
+            topMessage = "このたびは追加機能のご購入ありがとうございました。無料アップグレード対象のため、決済は発生しませんでした。ご注文内容はメールにてお送りしています。この画面を閉じる前にメールの到着を確認してください。";
+        } else {
+            topMessage = "ご注文ありがとうございました。無料アップグレード対象のため、決済は発生しませんでした。シリアル番号を発行いたしましたので、ご確認の上、大切に保管してください。シリアル番号はメールでもお送りしていますが、この画面を閉じる前にメールの到着を確認してください。";
+            labelMessage = "シリアル番号一覧";
+            message = "* " + props.serialnumbers.join("\n* ");
+        }
     }
     let price = props.orderFormData.quantity * props.productInformation.price;
 
@@ -104,19 +117,23 @@ const OrderFinished = (props) => {
                     </Col>
                 </>
             )}
+            {labelMessage && (<>
             <Col xs="12" md="3">
                 <p><label>{labelMessage}</label></p>
             </Col>
             <Col xs="12" md="9" className="mb-2">
-                <textarea rows="10" className="form-control" style={{overflow: "scroll"}} value={message} />
+                <textarea rows="10" className="form-control" style={{overflow: "scroll"}} value={message} readOnly />
             </Col>
+            </>)}
         </Row>
         <Row className="p2 mt-2">
+            {!isGradeUp && (
             <Col xs="12" md="8">
                 <p>上記内容は、なくさないように、大切に保管してください。</p>
             </Col>
+            )}
             <Col xs="12" md="4" className="text-end">
-                <Button variant="success" onClick={() => {window.location.href = settings.siteUrl}}>内容を確認し、保存しました</Button>
+                <Button variant="success" onClick={() => {window.location.href = settings.siteUrl}}>{isGradeUp ? "トップに戻る" : "内容を確認し、保存しました"}</Button>
             </Col>
         </Row>
     </>);

--- a/src/contents/main/OrderFinished.jsx
+++ b/src/contents/main/OrderFinished.jsx
@@ -65,6 +65,11 @@ const OrderFinished = (props) => {
             <p role="alert">{topMessage}</p>
         </Row>
         <Row className="p2">
+            {isGradeUp && props.orderFormData.paymentType !== "transfer" && (
+                <Col xs="12" className="mb-2">
+                    <p>追加した機能は、最初に入力いただいたシリアルキーに紐づけられています。お使いのソフトウェアのマニュアルに従い、再度認証を行ってください。</p>
+                </Col>
+            )}
             <Col xs="12" md="3">
                 <p><label>注文番号</label></p>
             </Col>

--- a/src/contents/main/Top.jsx
+++ b/src/contents/main/Top.jsx
@@ -27,7 +27,9 @@ const Top = (props) => {
     orderId: 0,
     couponCode: "",
     discountAmount: 0,
-    isCouponApplied: false
+    isCouponApplied: false,
+    serialNumber: "",
+    isSnValidated: false
   });
   const [productInformation, setProductInformation] = useState(null);
   const [initialized, setInitialized] = useState(false);
@@ -79,7 +81,8 @@ function getProductInformation(id, func){
         name: r.data.software.name,
         edition: r.data.software.edition,
         discription: r.data.software.discription,
-        price: r.data.software.price
+        price: r.data.software.price,
+        require_sn_prefix: r.data.software.require_sn_prefix ?? null
       });
     }
   }).catch((e) => {


### PR DESCRIPTION
これまで新規での購入だけでしたが、すでに購入済のシリアルキーを持っている人がグレードアップ購入する機能を設けます。

１．機能の判定

最初の/api/store/getproductでrequire_sn_prefixがnull以外で返却されていれば、それはグレードアップ商品です。

２．購入個数入力欄の変化

グレードアップ商品の場合、購入個数は１に固定されます。
この場合、クーポン利用時と同様に購入個数を変更できないようにしてください。

３．対象シリアルキー入力欄の新設

「シリアルキー」の入力欄を加えます。
形式：最大19桁の半角英数とハイフンで入力（本来16文字、４桁区切りでハイフン3か所の挿入は任意）
プレイスホルダ：○○ではじまるシリアルキーを入力
※○○の部分は最初の/api/store/getproductが返却するrequire_sn_prefixで置換
場所：メールアドレスと購入個数の間

４．次のステップへの移行制限

「お名前を、２文字以上で入力してください。」、「メールアドレスが誤っています。」と同様に、最初は「シリアルキーを入力し、確認ボタンを押してください。」のエラー表示をしておいてください。


５．確認ボタンの設置

入力欄の右に、「確認」ボタンを設置します。
未入力状態では押下できません。
押下されると、/api/store/grade_up_validateをたたきます。POSTリクエストで、パラメータは下記２つです。
product_id：クエリパラメータで指定されたプロダクトID
serial_number：ユーザー入力値
返却地はJSON固定で、次のいずれかです。
code:400,reason=エラーメッセージ
code:200,result:確認結果

確認結果が空文字の場合、入力が正しいことを示します。この場合、入力欄下部に「入力内容が確認されました。」と表示し、シリアルキーを書き換えできないようにしてください。同時に、「入力内容が確認されました。」というダイアログメッセージを表示してください。また、「シリアルキーを入力し、確認ボタンを押してください。」のエラーを解消とし、他の入力欄が正常であれば次のステップに進めるようにしてください。
それ以外の場合、エラーメッセージもしくは確認結果をダイアログに表示してください。ステータスコードが200以外であったり、上記に合致しない結果を受け取った場合は、いつものエラーメッセージをダイアログ表示しておいてください。

６．注文作成時の送信内容追加

グレードアップの場合、これまでの各項目に加えて、/api/store/orderにserial_numberを送信してください。

７．完了画面の変化

るれードアップの場合、購入完了時、orderやpayのAPIはserialnumbersを返却しません。
そのため、シリアルキーを表示しないでください。
それに合わせて、各種メッセージも矛盾しないように直してください。
追加機能の購入に謝意を表しておけばよいと思います。

グレードアップ時には、内容を確認し、保存しましたというボタンのテキストを「トップに戻る」にしてください。
